### PR TITLE
Visibility hidden

### DIFF
--- a/wasm/Driver.cpp
+++ b/wasm/Driver.cpp
@@ -184,7 +184,7 @@ static Optional<std::string> findFile(StringRef Path1, const Twine &Path2) {
 
 // Inject a new wasm global into the output binary with the given value.
 // Wasm global are used in relocatable object files to model symbol imports
-// and exports.  In the final exectuable the only use of wasm globals is the
+// and exports.  In the final executable the only use of wasm globals is
 // for the exlicit stack pointer (__stack_pointer).
 static void addSyntheticGlobal(StringRef Name, int32_t Value) {
   log("injecting global: " + Name);

--- a/wasm/SymbolTable.cpp
+++ b/wasm/SymbolTable.cpp
@@ -128,14 +128,14 @@ Symbol *SymbolTable::addDefined(InputFile *F, const WasmSymbol *Sym,
     S->update(Kind, F, Sym, Segment);
   } else if (Sym->isWeak()) {
     // the new symbol is weak we can ignore it
-    DEBUG(dbgs() << "existing symbol takes precensence\n");
+    DEBUG(dbgs() << "existing symbol takes precedence\n");
   } else if (S->isWeak()) {
     // the new symbol is not weak and the existing symbol is, so we replace
     // it
     DEBUG(dbgs() << "replacing existing weak symbol\n");
     S->update(Kind, F, Sym, Segment);
   } else {
-    // niether symbol is week. They conflict.
+    // neither symbol is week. They conflict.
     reportDuplicate(S, F);
   }
   return S;

--- a/wasm/Symbols.cpp
+++ b/wasm/Symbols.cpp
@@ -83,6 +83,8 @@ void Symbol::update(Kind K, InputFile *F, const WasmSymbol *WasmSym,
 
 bool Symbol::isWeak() const { return Sym && Sym->isWeak(); }
 
+bool Symbol::isHidden() const { return Sym && Sym->isHidden(); }
+
 std::string lld::toString(wasm::Symbol &Sym) {
   return wasm::displayName(Sym.getName());
 }

--- a/wasm/Symbols.h
+++ b/wasm/Symbols.h
@@ -57,6 +57,7 @@ public:
   bool isGlobal() const { return !isFunction(); }
   bool isLocal() const { return IsLocal; }
   bool isWeak() const;
+  bool isHidden() const;
 
   // Returns the symbol name.
   StringRef getName() const { return Name; }


### PR DESCRIPTION
I've added support for `-fvisibility=hidden` and `__attribute__((visibility("hidden")))` for the Wasm backend.

A corresponding change is needed in the upstream LLVM repository; I've submitted that via Phabricator. It's been some time since I last did work for LLVM, the process seems to be all new so I hope this is the right way to submit work.

The Phabricator review is here: https://reviews.llvm.org/D40442